### PR TITLE
Adding customization for "events" processing to Http client

### DIFF
--- a/.changeset/clean-dragons-return.md
+++ b/.changeset/clean-dragons-return.md
@@ -1,0 +1,5 @@
+---
+'apollo-angular': minor
+---
+
+Adding additional configurable support for the underlying Angular Http Client

--- a/.devcontainer/base.Dockerfile
+++ b/.devcontainer/base.Dockerfile
@@ -1,5 +1,5 @@
-# Update the VARIANT arg in devcontainer.json to pick a Node.js version: 14, 12, 10 
-ARG VARIANT=14
+# Update the VARIANT arg in devcontainer.json to pick a Node.js version: 14, 12, 10
+ARG VARIANT=18
 FROM node:${VARIANT}
 
 # Options for setup scripts
@@ -10,7 +10,7 @@ ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
 ENV NVM_DIR=/usr/local/share/nvm
-ENV NVM_SYMLINK_CURRENT=true \ 
+ENV NVM_SYMLINK_CURRENT=true \
     PATH=${NVM_DIR}/current/bin:${PATH}
 
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "build": {
     "dockerfile": "Dockerfile",
     // Update 'VARIANT' to pick a Node version: 10, 12, 14
-    "args": { "VARIANT": "14" }
+    "args": { "VARIANT": "18" }
   },
 
   // Set *default* container specific settings.json values on container create.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     ]
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "scripts": {
     "build": "yarn workspaces run build",

--- a/packages/apollo-angular/http/src/http-batch-link.ts
+++ b/packages/apollo-angular/http/src/http-batch-link.ts
@@ -1,5 +1,5 @@
 import { print } from 'graphql';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import {
   ApolloLink,
@@ -75,7 +75,13 @@ export class HttpBatchLinkHandler extends ApolloLink {
         const sub = fetch(req, this.httpClient, () => {
           throw new Error('File upload is not available when combined with Batching');
         }).subscribe({
-          next: result => observer.next(result.body),
+          next: result => {
+            if (result instanceof HttpResponse) {
+              observer.next(result.body);
+            } else {
+              observer.next(result);
+            }
+          },
           error: err => observer.error(err),
           complete: () => observer.complete(),
         });

--- a/packages/apollo-angular/http/src/types.ts
+++ b/packages/apollo-angular/http/src/types.ts
@@ -1,12 +1,26 @@
 import { DocumentNode } from 'graphql';
-import { HttpHeaders } from '@angular/common/http';
-import { Operation } from '@apollo/client/core';
+import { HttpContext, HttpEvent, HttpHeaders, HttpResponse } from '@angular/common/http';
+import { FetchResult, Operation } from '@apollo/client/core';
 
 export type HttpRequestOptions = {
   headers?: HttpHeaders;
+  context?: HttpContext;
   withCredentials?: boolean;
   useMultipart?: boolean;
+  observe?: 'body' | 'events' | 'response';
+  reportProgress?: boolean;
+  responseType?: 'json' | 'arraybuffer' | 'blob' | 'text';
+  params?: any;
+  body?: any;
 };
+
+export type HttpClientReturn =
+  | Object
+  | ArrayBuffer
+  | Blob
+  | string
+  | HttpResponse<Object | ArrayBuffer | Blob | string>
+  | HttpEvent<Object | ArrayBuffer | Blob | string>;
 
 export type URIFunction = (operation: Operation) => string;
 

--- a/packages/apollo-angular/src/subscription.ts
+++ b/packages/apollo-angular/src/subscription.ts
@@ -29,6 +29,6 @@ export abstract class Subscription<T = any, V extends OperationVariables = Empty
         query: this.document,
       },
       extra,
-    );
+    ) as Observable<SubscriptionResult<T>>;
   }
 }


### PR DESCRIPTION
### Checklist:

- [ ] If this PR is a new feature, please reference a discussion where a consensus about the design
      was reached (not necessary for small changes)
- [x] Make sure all the significant new logic is covered by tests

### About

Creating the ability to define in each request on the `context` input the different kinds of underlying Angular HttpClient options.

It is primarily suited to adding support for watching and 'event' of the HttpClient to determine events being emitted by the HttpClient as it processes the request/response.

Had to add the coercion of the FetchResult type to the SubscriptionResult type in `subscription.ts` or else Typescript was throwing errors for it.

Also includes bumping the versioning for the dev container as the current version doesn't work correctly with the engine version in `package.json` or the requirements of Angular itself.


