### PR TITLE
Drop support for node 18

### DIFF
--- a/.changeset/early-tigers-draw.md
+++ b/.changeset/early-tigers-draw.md
@@ -1,0 +1,5 @@
+---
+'apollo-angular': patch
+---
+
+Drop support for node 18

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,22 +114,13 @@ jobs:
       matrix:
         angular_version: [18, 19, 20]
         graphql_version: [16]
-        node_version: [18, 20, 22, 24]
+        node_version: [20, 22, 24]
         exclude:
           - angular_version: 18
-            node_version: 22
-
-          - angular_version: 18
             node_version: 24
 
           - angular_version: 19
-            node_version: 22
-
-          - angular_version: 19
             node_version: 24
-
-          - angular_version: 20
-            node_version: 18
     steps:
       - name: Use Node.js ${{ matrix.node_version }}
         uses: actions/setup-node@master


### PR DESCRIPTION
Because it is EOL
