### PR TITLE
Rename `onlyComplete()` into `onlyCompleteData()`

### DIFF
--- a/.changeset/rare-mangos-act.md
+++ b/.changeset/rare-mangos-act.md
@@ -1,0 +1,10 @@
+---
+'apollo-angular': patch
+---
+
+Rename `onlyComplete()` into `onlyCompleteData()`
+
+Because it communicates better that it is about the data, and not the
+stream being completed.
+
+`onlyComplete()` will be dropped in the next major version.

--- a/packages/apollo-angular/src/index.ts
+++ b/packages/apollo-angular/src/index.ts
@@ -8,4 +8,4 @@ export { Subscription } from './subscription';
 export { APOLLO_OPTIONS, APOLLO_NAMED_OPTIONS, APOLLO_FLAGS } from './tokens';
 export type { Flags, NamedOptions, ResultOf, VariablesOf } from './types';
 export { gql } from './gql';
-export { onlyComplete } from './only-complete';
+export { onlyCompleteData, onlyComplete } from './only-complete-data';

--- a/packages/apollo-angular/src/only-complete-data.ts
+++ b/packages/apollo-angular/src/only-complete-data.ts
@@ -19,13 +19,13 @@ import type { ObservableQuery } from '@apollo/client/core';
  *     notifyOnNetworkStatusChange: false, // Adding this will save CPU cycles
  *   })
  *   .valueChanges
- *   .pipe(onlyComplete())
+ *   .pipe(onlyCompleteData())
  *   .subscribe(result => {
  *     // Do something with complete result
  *   });
  * ```
  */
-export function onlyComplete<TData>(): OperatorFunction<
+export function onlyCompleteData<TData>(): OperatorFunction<
   ObservableQuery.Result<TData>,
   ObservableQuery.Result<TData, 'complete'>
 > {
@@ -34,3 +34,8 @@ export function onlyComplete<TData>(): OperatorFunction<
       result.dataState === 'complete',
   );
 }
+
+/**
+ * @deprecated Use `onlyCompleteData()` instead.
+ */
+export const onlyComplete = onlyCompleteData;

--- a/packages/apollo-angular/testing/tests/only-complete-data.spec.ts
+++ b/packages/apollo-angular/testing/tests/only-complete-data.spec.ts
@@ -1,4 +1,4 @@
-import { onlyComplete } from 'apollo-angular';
+import { onlyCompleteData } from 'apollo-angular';
 import { Subject } from 'rxjs';
 import { describe, expect, test } from 'vitest';
 import { NetworkStatus, ObservableQuery } from '@apollo/client/core';
@@ -9,14 +9,14 @@ interface Result {
   };
 }
 
-describe('onlyComplete', () => {
+describe('onlyCompleteData', () => {
   let theUser: Result['user'] | null = null;
   let count = 0;
 
   test('should receive only complete results', () =>
     new Promise<void>(done => {
       const b = new Subject<ObservableQuery.Result<Result>>();
-      b.pipe(onlyComplete()).subscribe({
+      b.pipe(onlyCompleteData()).subscribe({
         next: result => {
           count++;
           theUser = result.data.user;

--- a/packages/demo/src/app/pages/movie/movie-page.component.ts
+++ b/packages/demo/src/app/pages/movie/movie-page.component.ts
@@ -1,4 +1,4 @@
-import { Apollo, gql, onlyComplete } from 'apollo-angular';
+import { Apollo, gql, onlyCompleteData } from 'apollo-angular';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { AsyncPipe } from '@angular/common';
@@ -72,7 +72,7 @@ export class MoviePageComponent implements OnInit {
         notifyOnNetworkStatusChange: false,
       })
       .valueChanges.pipe(
-        onlyComplete(),
+        onlyCompleteData(),
         map(result => result.data.film),
       );
   }

--- a/packages/demo/src/app/pages/movies/movies-page.component.ts
+++ b/packages/demo/src/app/pages/movies/movies-page.component.ts
@@ -1,4 +1,4 @@
-import { Apollo, gql, onlyComplete } from 'apollo-angular';
+import { Apollo, gql, onlyCompleteData } from 'apollo-angular';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { AsyncPipe } from '@angular/common';
@@ -59,7 +59,7 @@ export class MoviesPageComponent implements OnInit {
         notifyOnNetworkStatusChange: false,
       })
       .valueChanges.pipe(
-        onlyComplete(),
+        onlyCompleteData(),
         map(result => result.data.allFilms.films),
       );
   }


### PR DESCRIPTION
Because it communicates better that it is about the data, and not the stream being completed.

`onlyComplete()` will be dropped in the next major version.

