### PR TITLE
docs: clarify query lifecycle timing

### DIFF
--- a/website/src/pages/docs/data/queries.mdx
+++ b/website/src/pages/docs/data/queries.mdx
@@ -68,6 +68,20 @@ class PostsComponent implements OnInit, OnDestroy {
 }
 ```
 
+<Callout>
+  The constructor parameter asks Angular's dependency injector for `Apollo`; it does not start the
+  query. This example starts `watchQuery` in `ngOnInit`, which runs once after Angular assigns the
+  component's initial inputs. `inject(Apollo)` in a field initializer is an equivalent way to
+  obtain the service.
+
+  If query variables come from an `@Input()` that can change later, initialize the `QueryRef` with
+  that first value in `ngOnInit`, then update it with `setVariables()` on later calls to
+  `ngOnChanges`. You can also drive those updates from an input signal or Observable pipeline;
+  `ngOnInit` itself does not run again. This [worked lifecycle
+  comparison](https://frontendatlas.com/angular/trivia/angular-ngoninit-vs-constructor) explains the
+  timing trade-offs.
+</Callout>
+
 The `watchQuery` method returns a `QueryRef` object which has the `valueChanges` property that is an
 `Observable`.
 


### PR DESCRIPTION
## Summary

- clarify that the example obtains `Apollo` during construction but starts the query in `ngOnInit`
- explain how to update input-derived query variables after initialization

## Verification

- [x] Reviewed the rendered Markdown preview
- [x] Cross-checked the lifecycle timing and current `QueryRef.setVariables()` API
- [ ] Full website build (not run in this browser-only documentation workflow)

### Checklist

- [x] This is a small documentation clarification; no feature-design discussion is required.
- [x] No runtime logic was added, so no runtime test or changeset is needed.

### Disclosure

I maintain FrontendAtlas, the optional external resource linked once in the added note. The Apollo-specific guidance stands on its own without that link, and I am happy to remove it if the project prefers first-party-only references.

This contribution was prepared with AI assistance. I reviewed and validated the final wording and technical claims before submission.